### PR TITLE
handle the scenario where the output path has a nested folder structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ TreeSync.prototype.sync = function() {
         return fs.writeFileSync(outputFullpath, fs.readFileSync(inputFullpath));
       case 'mkdir' :
         try {
-          return fs.mkdirSync(outputFullpath);
+          return mkdirp.sync(outputFullpath);
         } catch(e) {
           if (e && e.code === 'EEXIST') { /* do nothing */ }
           else { throw e; }


### PR DESCRIPTION
I was receiving an error in ember-cli-build.js when using a broccoli funnel that specified an output folder which was contained a nested folder of not-yet-created folders.