### PR TITLE
[BUGFIX] rmdir should have been sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ TreeSync.prototype.sync = function() {
         }
         break;
       case 'rmdir':
-        return fs.rmdir(outputFullpath);
+        return fs.rmdirSync(outputFullpath);
       default:
         throw TypeError('Unknown operation:' + operation + ' on path: ' + pathname);
     }

--- a/tests/index.js
+++ b/tests/index.js
@@ -59,6 +59,41 @@ describe('TreeSync', function() {
       });
     });
 
+
+    describe('rmdir operation is sync', function() {
+      var newFolderPath = __dirname + '/fixtures/two';
+
+      beforeEach(function() {
+        fs.mkdirSync(newFolderPath);
+        treeSync.sync(); // setup initialk
+      });
+
+      beforeEach(function() {
+        fs.rmdirSync(newFolderPath);
+      });
+
+      it('immediately reflects deletions', function() {
+        var beforeTree = walkSync(tmp);
+        expect(beforeTree).to.deep.equal([
+          'one/',
+          'one/bar/',
+          'one/bar/bar.txt',
+          'one/foo.txt',
+          'two/'
+        ]);
+
+        treeSync.sync();
+        var afterTree = walkSync(tmp);
+
+        expect(afterTree).to.deep.equal([
+          'one/',
+          'one/bar/',
+          'one/bar/bar.txt',
+          'one/foo.txt'
+        ]);
+      });
+    });
+
     describe('input(same) -> input(same)', function() {
       beforeEach(function() {
         treeSync.sync(); // setup initial


### PR DESCRIPTION
This fixing node 7 warning, and likely other race related issues...

```
(node:30319) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```