### PR TITLE
sync returns list of changed files

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,4 +85,9 @@ TreeSync.prototype.sync = function() {
 
   this._hasSynced = true;
   debug('applied patches: %d', operations.length);
+
+  // Return only type and name; don't want downstream relying on entries.
+  return operations.map(function (op) {
+    return op.slice(0,2);
+  });
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -113,6 +113,23 @@ describe('TreeSync', function() {
       });
     });
 
+    describe('.sync', function() {
+      it('returns a list of changed files', function() {
+        var beforeTree = walkSync.entries(tmp);
+
+        expect(beforeTree.length).to.eql(0);
+
+        var changes = treeSync.sync();
+
+        expect(changes).to.eql([
+          ['mkdir',   'one/'],
+          ['mkdir',   'one/bar/'],
+          ['create',  'one/bar/bar.txt'],
+          ['create',  'one/foo.txt']
+        ]);
+      });
+    });
+
     describe('input(same) -> input(same + newFile)', function() {
       var newFilePath = __dirname + '/fixtures/one/added-file.js';
 


### PR DESCRIPTION
This is useful so the build can report what output changed in this build (eg
whether css changed, vendor, app, index.html &c.)